### PR TITLE
Remove missing sensor from energy group

### DIFF
--- a/configuration/groups.yaml
+++ b/configuration/groups.yaml
@@ -19,7 +19,6 @@
       - sensor.lds_zb_onoffplug_d0005_electrical_measurement
       - sensor.flood_light_usage
       - sensor.dishwasher_power
-      - sensor.fan_heater_electrical_measurement
       - sensor.olivers_computer_electrical_measurement
       - sensor.joshua_computer_power_electric_consumption_w
       - sensor.adams_computer_electric_consumption_w


### PR DESCRIPTION
sensor.fan_heater_electrical_measurement no longer exists.